### PR TITLE
fix: add header before starting each recipe

### DIFF
--- a/src/commands/react-native-ci-cli.ts
+++ b/src/commands/react-native-ci-cli.ts
@@ -90,9 +90,7 @@ const runReactNativeCiCli = async (toolbox: CycliToolbox) => {
     return
   }
 
-  toolbox.interactive.outro("Let's roll")
-
-  toolbox.interactive.step(
+  toolbox.interactive.surveyStep(
     `Detected ${context.packageManager} as your package manager.`
   )
 
@@ -112,7 +110,6 @@ const runReactNativeCiCli = async (toolbox: CycliToolbox) => {
 
   const usedFlags = executorResults.join(' ')
 
-  toolbox.interactive.vspace()
   toolbox.interactive.success(`We're all set 🎉`)
 
   if (!toolbox.options.isPreset()) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const COLORS = {
 export const S_STEP_WARNING = COLORS.yellow('▲')
 export const S_STEP_ERROR = COLORS.red('■')
 export const S_STEP_SUCCESS = COLORS.green('◇')
+export const S_SUCCESS = COLORS.green('◆')
 export const S_CONFIRM = COLORS.magenta('◆')
 export const S_ACTION = COLORS.cyan('▼')
 export const S_ACTION_BULLET = COLORS.cyan('►')

--- a/src/extensions/interactive.ts
+++ b/src/extensions/interactive.ts
@@ -21,6 +21,7 @@ import {
   S_STEP_ERROR,
   S_STEP_SUCCESS,
   S_STEP_WARNING,
+  S_SUCCESS,
   S_UL,
   S_UR,
   S_VBAR,
@@ -33,8 +34,17 @@ interface Spinner {
 const DEFAULT_HEADER_WIDTH = 80
 
 module.exports = (toolbox: CycliToolbox) => {
-  const { bold, cyan, magenta, yellow, gray, inverse, dim, strikethrough } =
-    COLORS
+  const {
+    bold,
+    cyan,
+    magenta,
+    yellow,
+    gray,
+    green,
+    inverse,
+    dim,
+    strikethrough,
+  } = COLORS
 
   const withNewlinePrefix = (message: string, prefix: string): string =>
     message.split('\n').join(`\n${prefix}  `)
@@ -222,7 +232,7 @@ module.exports = (toolbox: CycliToolbox) => {
   }
 
   const success = (message: string) => {
-    print.success(message)
+    print.info(`${S_SUCCESS} ${green(message)}`)
   }
 
   const warning = (message: string) => {
@@ -271,7 +281,7 @@ module.exports = (toolbox: CycliToolbox) => {
   ): Promise<void> => {
     return new Promise((resolve, reject) => {
       vspace()
-      sectionHeader(`Running ${processName}...`)
+      sectionHeader(`Running ${processName}...`, { color: 'dim' })
 
       const subprocess = spawn(command, {
         stdio: ['inherit', 'inherit', alwaysPrintStderr ? 'inherit' : 'pipe'],
@@ -299,7 +309,7 @@ module.exports = (toolbox: CycliToolbox) => {
           step(`Finished running ${processName}.`)
         }
 
-        sectionFooter()
+        sectionFooter({ color: 'dim' })
         vspace()
 
         if (code !== 0) {

--- a/src/recipes/build-release.ts
+++ b/src/recipes/build-release.ts
@@ -20,7 +20,7 @@ const createReleaseBuildWorkflowAndroid = async (
     context
   )
 
-  toolbox.interactive.step('Created Android release build workflow.')
+  toolbox.interactive.success('Created Android release build workflow.')
 }
 
 const createReleaseBuildWorkflowIOs = async (
@@ -55,7 +55,7 @@ const createReleaseBuildWorkflowIOs = async (
     }
   )
 
-  toolbox.interactive.step('Created iOS release build workflow.')
+  toolbox.interactive.success('Created iOS release build workflow.')
 }
 
 export const createReleaseBuildWorkflows = async (
@@ -68,11 +68,10 @@ export const createReleaseBuildWorkflows = async (
 
   if (expo) {
     toolbox.print.info('⚙️ Running expo prebuild to setup app.json properly.')
-    await toolbox.system.spawn(
+    await toolbox.interactive.spawnSubprocess(
+      'Expo prebuild',
       `npx expo prebuild --${context.packageManager}`,
-      {
-        stdio: 'inherit',
-      }
+      { alwaysPrintStderr: true }
     )
   }
 
@@ -86,12 +85,6 @@ export const createReleaseBuildWorkflows = async (
       'Failed to obtain iOS app name. Perhaps your ios/ directory is missing .xcworkspace file.'
     )
   }
-  toolbox.print.info('⚙️ Running expo prebuild to setup app.json properly.')
-  await toolbox.interactive.spawnSubprocess(
-    'Expo prebuild',
-    `npx expo prebuild --${context.packageManager}`,
-    { alwaysPrintStderr: true }
-  )
 
   if (platforms.includes('android')) {
     await createReleaseBuildWorkflowAndroid(toolbox, context, { expo })

--- a/src/recipes/detox.ts
+++ b/src/recipes/detox.ts
@@ -44,7 +44,8 @@ const createDetoxWorkflows = async (
   context: ProjectContext,
   { expo }: { expo: boolean }
 ) => {
-  toolbox.interactive.info('⚙️ Setting up app release build for Detox.')
+  toolbox.interactive.vspace()
+  toolbox.interactive.sectionHeader('Genereating Detox workflow')
 
   await createReleaseBuildWorkflows(toolbox, context, {
     platforms: ['android', 'ios'],
@@ -116,7 +117,7 @@ const createDetoxWorkflows = async (
 
   await toolbox.workflows.generate(join('detox', 'test-detox-ios.ejf'), context)
 
-  toolbox.interactive.step('Created Detox workflow.')
+  toolbox.interactive.success('Created Detox workflow.')
 
   toolbox.interactive.warning(
     `Remember to create GH_TOKEN repository secret to make Detox workflow work.For more information check ${REPOSITORY_SECRETS_HELP_URL} `

--- a/src/recipes/eas-update.ts
+++ b/src/recipes/eas-update.ts
@@ -6,6 +6,11 @@ const FLAG = 'eas-update'
 
 const execute =
   () => async (toolbox: CycliToolbox, context: ProjectContext) => {
+    toolbox.interactive.vspace()
+    toolbox.interactive.sectionHeader(
+      'Genereating EAS Update and Preview workflow'
+    )
+
     toolbox.dependencies.add('expo', context)
 
     if (toolbox.filesystem.exists('eas.json')) {
@@ -28,7 +33,7 @@ const execute =
 
     await toolbox.workflows.generate(join('eas', 'eas-update.ejf'), context)
 
-    toolbox.interactive.step('Created EAS Update workflow.')
+    toolbox.interactive.success('Created EAS Update and Preview workflow.')
 
     toolbox.interactive.warning(
       `Remember to create repository secret EXPO_TOKEN for EAS Update workflow to work properly. For more information check ${REPOSITORY_SECRETS_HELP_URL}`

--- a/src/recipes/jest.ts
+++ b/src/recipes/jest.ts
@@ -9,6 +9,9 @@ const existsJestConfiguration = (toolbox: CycliToolbox): boolean =>
 
 const execute =
   () => async (toolbox: CycliToolbox, context: ProjectContext) => {
+    toolbox.interactive.vspace()
+    toolbox.interactive.sectionHeader('Genereating Jest workflow')
+
     await toolbox.dependencies.addDev('jest', context)
 
     await toolbox.scripts.add('test', 'jest')
@@ -26,7 +29,7 @@ const execute =
 
     await toolbox.workflows.generate(join('jest', 'jest.ejf'), context)
 
-    toolbox.interactive.step('Created Jest workflow.')
+    toolbox.interactive.success('Created Jest workflow.')
 
     return `--${FLAG}`
   }

--- a/src/recipes/lint.ts
+++ b/src/recipes/lint.ts
@@ -22,6 +22,9 @@ const existsEslintConfiguration = (toolbox: CycliToolbox): boolean =>
 
 const execute =
   () => async (toolbox: CycliToolbox, context: ProjectContext) => {
+    toolbox.interactive.vspace()
+    toolbox.interactive.sectionHeader('Genereating ESLint workflow')
+
     // eslint@9 introduces new configuration format that is not supported by widely used plugins yet,
     // so we stick to ^8 for now.
     await toolbox.dependencies.addDev('eslint', context, { version: '^8' })
@@ -55,7 +58,7 @@ const execute =
 
     await toolbox.workflows.generate(join('lint', 'lint.ejf'), context)
 
-    toolbox.interactive.step('Created ESLint workflow.')
+    toolbox.interactive.success('Created ESLint workflow.')
 
     return `--${FLAG}`
   }

--- a/src/recipes/prettier.ts
+++ b/src/recipes/prettier.ts
@@ -15,6 +15,9 @@ const existsPrettierConfiguration = (toolbox: CycliToolbox): boolean =>
 
 const execute =
   () => async (toolbox: CycliToolbox, context: ProjectContext) => {
+    toolbox.interactive.vspace()
+    toolbox.interactive.sectionHeader('Genereating Prettier check workflow')
+
     await toolbox.dependencies.addDev('prettier', context)
 
     await toolbox.scripts.add(
@@ -47,7 +50,7 @@ const execute =
       toolbox.interactive.step('Created default .prettierignore file.')
     }
 
-    toolbox.interactive.step('Created Prettier check workflow.')
+    toolbox.interactive.success('Created Prettier check workflow.')
 
     return `--${FLAG}`
   }

--- a/src/recipes/typescript.ts
+++ b/src/recipes/typescript.ts
@@ -5,6 +5,9 @@ const FLAG = 'ts'
 
 const execute =
   () => async (toolbox: CycliToolbox, context: ProjectContext) => {
+    toolbox.interactive.vspace()
+    toolbox.interactive.sectionHeader('Genereating Typescript check workflow')
+
     await toolbox.dependencies.addDev('typescript', context)
 
     await toolbox.scripts.add('ts:check', 'tsc -p . --noEmit')
@@ -25,7 +28,7 @@ const execute =
       )
     }
 
-    toolbox.interactive.step('Created Typescript check workflow.')
+    toolbox.interactive.success('Created Typescript check workflow.')
 
     return `--${FLAG}`
   }


### PR DESCRIPTION
Resolves #71 

![Zrzut ekranu 2024-08-26 o 11 32 17](https://github.com/user-attachments/assets/e3e712ec-ccbe-4ed2-bef5-5d8a7e571ac4)

## Changes

- add header before starting each recipe executor
- make headers for subprocesses dimmed to make them easier to visually distinguish from recipe headers
- change style of 'Created XYZ workflow' to green text to make them more apparent