### PR TITLE
feat: add bun support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,7 @@ export const PRESET_FLAG = 'preset'
 export const LOCK_FILE_TO_MANAGER = {
   ['yarn.lock']: 'yarn',
   ['package-lock.json']: 'npm',
+  ['bun.lockb']: 'bun'
 } as const
 
 const REPOSITORY_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export const PRESET_FLAG = 'preset'
 export const LOCK_FILE_TO_MANAGER = {
   ['yarn.lock']: 'yarn',
   ['package-lock.json']: 'npm',
-  ['bun.lockb']: 'bun'
+  ['bun.lockb']: 'bun',
 } as const
 
 const REPOSITORY_URL =

--- a/src/templates/build-release/build-release-android.ejf
+++ b/src/templates/build-release/build-release-android.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const build = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:android`,
-  npm: `npm run build:release:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run build:release:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:android`
 }
 %>
 
@@ -34,7 +36,7 @@ jobs:
           key: android-release-build-${{ github.event.pull_request.head.sha }}
 
   build-release-android:
-    needs: lookup-cached-build 
+    needs: lookup-cached-build
     if: needs.lookup-cached-build.outputs.build-exists != 'true'
     runs-on: ubuntu-latest
     steps:
@@ -66,7 +68,7 @@ jobs:
       - name: 🛠️ Build
         run: <%= build[props.packageManager] %>
 
-      - name: 📁 Prepare cache folder 
+      - name: 📁 Prepare cache folder
         run: |
           mkdir android-release-build
           mv <%= props.pathRelativeToRoot %>/android/app/build/outputs/apk/release/app-release.apk android-release-build/android-release.apk

--- a/src/templates/build-release/build-release-android.ejf
+++ b/src/templates/build-release/build-release-android.ejf
@@ -51,6 +51,11 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
+      <%= if(props.packageManager === "bun") { %>
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      <%= } %>
+
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>
 

--- a/src/templates/build-release/build-release-ios.ejf
+++ b/src/templates/build-release/build-release-ios.ejf
@@ -43,6 +43,11 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
+      <%= if(props.packageManager === "bun") { %>
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      <%= } %>
+
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>
 

--- a/src/templates/build-release/build-release-ios.ejf
+++ b/src/templates/build-release/build-release-ios.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const build = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:ios`,
-  npm: `npm run build:release:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run build:release:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:ios`
 }
 %>
 
@@ -34,7 +36,7 @@ jobs:
           key: ios-release-build-${{ github.event.pull_request.head.sha }}
 
   build-release-ios:
-    needs: lookup-cached-build 
+    needs: lookup-cached-build
     if: needs.lookup-cached-build.outputs.build-exists != 'true'
     runs-on: macos-latest
     steps:
@@ -52,7 +54,7 @@ jobs:
       - name: 🛠️ Build
         run: <%= build[props.packageManager] %>
 
-      - name: 📁 Prepare cache folder 
+      - name: 📁 Prepare cache folder
         run: |
           mkdir ios-release-build
           mv <%= props.pathRelativeToRoot %>/ios/build/Build/Products/Release-iphonesimulator/<%= props.iOSAppName %>.app ios-release-build/ios-release.app

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -41,6 +41,11 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
+      <%= if(props.packageManager === "bun") { %>
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      <%= } %>
+
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>
 

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const runTests = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:android`,
-  npm: `npm run detox:test:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run detox:test:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:android`
 }
 %>
 
@@ -74,7 +76,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-  
+
       - name: 📱 AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -83,7 +85,7 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ env.API_LEVEL }}
-      
+
       - name: 📋 Run Detox tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       <%= if(props.packageManager === "bun") { %>
-      - name: Install Bun
+      - name: 🥟 Install Bun
         uses: oven-sh/setup-bun@v2
       <%= } %>
 

--- a/src/templates/detox/test-detox-ios.ejf
+++ b/src/templates/detox/test-detox-ios.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const runTests = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:ios`,
-  npm: `npm run detox:test:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run detox:test:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:ios`
 }
 %>
 

--- a/src/templates/detox/test-detox-ios.ejf
+++ b/src/templates/detox/test-detox-ios.ejf
@@ -39,6 +39,11 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
+      <%= if(props.packageManager === "bun") { %>
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      <%= } %>
+
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>
 

--- a/src/templates/eas/eas-update.ejf
+++ b/src/templates/eas/eas-update.ejf
@@ -3,7 +3,8 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 %>
 

--- a/src/templates/eas/eas-update.ejf
+++ b/src/templates/eas/eas-update.ejf
@@ -32,6 +32,11 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
+      <%= if(props.packageManager === "bun") { %>
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+      <%= } %>
+
       - name: ⚙️ Setup EAS
         uses: expo/expo-github-action@v8
         with:

--- a/src/templates/jest/jest.ejf
+++ b/src/templates/jest/jest.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const run = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}test`,
-  npm: `npm run test ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run test ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}test`
 }
 %>
 

--- a/src/templates/jest/jest.ejf
+++ b/src/templates/jest/jest.ejf
@@ -29,6 +29,11 @@ jobs:
          - name: 🏗 Setup repo
            uses: actions/checkout@v4
 
+        <%= if(props.packageManager === "bun") { %>
+         - name: Install Bun
+           uses: oven-sh/setup-bun@v2
+        <%= } %>
+
          - name: 📦 Install dependencies
            run: <%= install[props.packageManager] %>
 

--- a/src/templates/lint/lint.ejf
+++ b/src/templates/lint/lint.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const run = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}lint`,
-  npm: `npm run lint ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run lint ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}lint`
 }
 %>
 
@@ -18,7 +20,7 @@ on:
   pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
- 
+
 jobs:
    eslint:
       name: ESLint

--- a/src/templates/lint/lint.ejf
+++ b/src/templates/lint/lint.ejf
@@ -29,6 +29,11 @@ jobs:
          - name: 🏗 Setup repo
            uses: actions/checkout@v4
 
+        <%= if(props.packageManager === "bun") { %>
+         - name: Install Bun
+           uses: oven-sh/setup-bun@v2
+        <%= } %>
+
          - name: 📦 Install dependencies
            run: <%= install[props.packageManager] %>
 

--- a/src/templates/prettier/prettier.ejf
+++ b/src/templates/prettier/prettier.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const run = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}prettier:check`,
-  npm: `npm run prettier:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run prettier:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}prettier:check`
 }
 %>
 

--- a/src/templates/prettier/prettier.ejf
+++ b/src/templates/prettier/prettier.ejf
@@ -29,6 +29,11 @@ jobs:
          - name: 🏗 Setup repo
            uses: actions/checkout@v4
 
+        <%= if(props.packageManager === "bun") { %>
+         - name: Install Bun
+           uses: oven-sh/setup-bun@v2
+        <%= } %>
+
          - name: 📦 Install dependencies
            run: <%= install[props.packageManager] %>
 

--- a/src/templates/typescript/typescript.ejf
+++ b/src/templates/typescript/typescript.ejf
@@ -3,12 +3,14 @@ const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
   yarn: "yarn",
-  npm: "npm install"
+  npm: "npm install",
+  bun: "bun install"
 }
 
 const run = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}ts:check`,
-  npm: `npm run ts:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
+  npm: `npm run ts:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`,
+  bun: `bun run ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}ts:check`
 }
 %>
 

--- a/src/templates/typescript/typescript.ejf
+++ b/src/templates/typescript/typescript.ejf
@@ -29,6 +29,11 @@ jobs:
          - name: 🏗 Setup repo
            uses: actions/checkout@v4
 
+        <%= if(props.packageManager === "bun") { %>
+         - name: Install Bun
+           uses: oven-sh/setup-bun@v2
+        <%= } %>
+
          - name: 📦 Install dependencies
            run: <%= install[props.packageManager] %>
 


### PR DESCRIPTION
to support : #87 

- added bun to templates (need to verify --cwd does what i expect)
- added bun detection in the package manager
- add to the github action bun bin (`- uses: oven-sh/setup-bun@v2`)

left to do as far as i know:
- see if gluegun can support bun easily or not
- check what kind of tests i need to run to check it works as intended