### PR TITLE
fix: release workflow syntax error

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,6 +1,12 @@
 name: Run Jest
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'readme.md'
 
 jobs:
   jest:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PA_TOKEN }}
 


### PR DESCRIPTION
## Changes 

1. Fix syntax error in `release.yml`
2. Add `paths-ignore` field to `jest.yml` workflow to not run tests in changes to `.github/`, `docs/`, `CHANGELOG.md` and `readme.md`