### PR TITLE
fix: use node version file in maestro and debug build workflows

### DIFF
--- a/src/templates/build-debug/build-debug-android.ejf
+++ b/src/templates/build-debug/build-debug-android.ejf
@@ -45,10 +45,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: ☕ Setup JDK 17

--- a/src/templates/build-debug/build-debug-ios.ejf
+++ b/src/templates/build-debug/build-debug-ios.ejf
@@ -37,10 +37,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 🔨 Use latest stable Xcode

--- a/src/templates/build-debug/lookup-cached-debug-build.ejf
+++ b/src/templates/build-debug/lookup-cached-debug-build.ejf
@@ -49,10 +49,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/maestro/maestro-test-android.ejf
+++ b/src/templates/maestro/maestro-test-android.ejf
@@ -52,10 +52,10 @@ jobs:
           path: android-debug-build/
           key: ${{ needs.build-debug-android.outputs.build-cache-key }}
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: ☕ Setup JDK 17

--- a/src/templates/maestro/maestro-test-ios.ejf
+++ b/src/templates/maestro/maestro-test-ios.ejf
@@ -50,10 +50,10 @@ jobs:
           path: ios-debug-build/
           key: ${{ needs.build-debug-ios.outputs.build-cache-key }}
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: ☕ Setup JDK 17


### PR DESCRIPTION
This has been overlooked when merging Maestro recipe (reading node version from file was developed parallelly)