### PR TITLE
feat: build debug app on push to main

### DIFF
--- a/src/templates/build-debug/build-debug-android.ejf
+++ b/src/templates/build-debug/build-debug-android.ejf
@@ -15,6 +15,9 @@ const build = {
 name: Build Android Debug App
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
     outputs:
       build-cache-key:

--- a/src/templates/build-debug/build-debug-android.ejf
+++ b/src/templates/build-debug/build-debug-android.ejf
@@ -17,7 +17,7 @@ name: Build Android Debug App
 on:
   push:
     branches:
-      - main
+      - main # Build on main for caching purposes, this way every branch will have access to it
   workflow_call:
     outputs:
       build-cache-key:

--- a/src/templates/build-debug/build-debug-ios.ejf
+++ b/src/templates/build-debug/build-debug-ios.ejf
@@ -15,6 +15,9 @@ const build = {
 name: Build iOS Debug App
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
     outputs:
       build-cache-key:

--- a/src/templates/build-debug/build-debug-ios.ejf
+++ b/src/templates/build-debug/build-debug-ios.ejf
@@ -17,7 +17,7 @@ name: Build iOS Debug App
 on:
   push:
     branches:
-      - main
+      - main # Build on main for caching purposes, this way every branch will have access to it
   workflow_call:
     outputs:
       build-cache-key:


### PR DESCRIPTION
Resolves #106 

Since cache between Pull Requests is not shared (https://github.com/actions/cache/issues/79), but cache from `main` branch is visible for all other branches, this will trigger debug builds that will be reused in Pull Requests not changing native code compared to main branch.

This will cut down the number of builds significantly (without it, at least one build will always be performed in every Pull Request)