### PR TITLE
fix: build dev script after name migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc -p .",
     "copy-templates": "cp -r ./src/templates/ ./build/templates",
     "build": "yarn clean-build && yarn compile && yarn copy-templates",
-    "build:dev": "sed -i 's/\"name\": \"react-native-ci-cli\"/\"name\": \"setup-ci\"/g' package.json && yarn build",
+    "build:dev": "sed -i 's/\"name\": \"setup-ci\"/\"name\": \"react-native-ci-cli\"/g' package.json && yarn build",
     "bump:dev": "node scripts/bump-version-dev.ts",
     "prepublishOnly": "yarn build",
     "test": "jest --runInBand --bail --verbose",


### PR DESCRIPTION
Change order of sed arguments to replace 

`setup-ci` -> `react-native-ci-cli`

instead of 

`react-native-ci-cli` -> `setup-ci`