### PR TITLE
fix: subprocess flaky input

### DIFF
--- a/src/extensions/expo.ts
+++ b/src/extensions/expo.ts
@@ -1,16 +1,16 @@
 import { CycliToolbox, ProjectContext, Platform, Environment } from '../types'
 
 module.exports = (toolbox: CycliToolbox) => {
-  const prebuild = async (
+  const prebuild = (
     context: ProjectContext,
     { cleanAfter }: { cleanAfter: boolean }
-  ): Promise<void> => {
+  ) => {
     const existsAndroidDir = toolbox.filesystem.exists('android')
     const existsIOsDir = toolbox.filesystem.exists('ios')
 
     toolbox.print.info('⚙️ Running expo prebuild to setup app configuration.')
 
-    await toolbox.interactive.spawnSubprocess(
+    toolbox.interactive.spawnSubprocess(
       'Expo prebuild',
       `npx expo prebuild --${context.packageManager}`,
       { alwaysPrintStderr: true }
@@ -23,7 +23,7 @@ module.exports = (toolbox: CycliToolbox) => {
   }
 
   const buildConfigure = async (): Promise<void> => {
-    await toolbox.interactive.spawnSubprocess(
+    toolbox.interactive.spawnSubprocess(
       'EAS Build configuration',
       'npx eas-cli build:configure -p all'
     )
@@ -31,8 +31,8 @@ module.exports = (toolbox: CycliToolbox) => {
     toolbox.interactive.step('Created default EAS Build configuration.')
   }
 
-  const updateConfigure = async (): Promise<void> => {
-    await toolbox.interactive.spawnSubprocess(
+  const updateConfigure = async () => {
+    toolbox.interactive.spawnSubprocess(
       'EAS Update configuration',
       'npx eas-cli update:configure'
     )
@@ -40,16 +40,16 @@ module.exports = (toolbox: CycliToolbox) => {
     toolbox.interactive.step('Created default EAS Update configuration.')
   }
 
-  const credentialsConfigureBuild = async ({
+  const credentialsConfigureBuild = ({
     platform,
     environment,
   }: {
     platform: Platform
     environment: Environment
-  }): Promise<void> => {
+  }) => {
     const platformName = platform === 'android' ? 'Android' : 'iOS'
 
-    await toolbox.interactive.spawnSubprocess(
+    toolbox.interactive.spawnSubprocess(
       `EAS Credentials configuration for ${platformName}`,
       `npx eas-cli credentials:configure-build -p ${platform} -e ${environment}`
     )
@@ -72,17 +72,17 @@ export interface ExpoExtension {
     prebuild: (
       context: ProjectContext,
       { cleanAfter }: { cleanAfter: boolean }
-    ) => Promise<void>
+    ) => void
     eas: {
-      buildConfigure: () => Promise<void>
-      updateConfigure: () => Promise<void>
+      buildConfigure: () => void
+      updateConfigure: () => void
       credentialsConfigureBuild: ({
         platform,
         environment,
       }: {
         platform: Platform
         environment: Environment
-      }) => Promise<void>
+      }) => void
     }
   }
 }

--- a/src/extensions/interactive.ts
+++ b/src/extensions/interactive.ts
@@ -441,11 +441,11 @@ module.exports = (toolbox: CycliToolbox) => {
     info(`${S_UR}\n${S_DL}${S_VBAR.repeat(width - 1)}`, color)
   }
 
-  const spawnSubprocess = async (
+  const spawnSubprocess = (
     processName: string,
     command: string,
     { alwaysPrintStderr = false }: { alwaysPrintStderr?: boolean } = {}
-  ): Promise<void> => {
+  ) => {
     vspace()
     sectionHeader(`Running ${processName}...`, { color: 'dim' })
 
@@ -541,6 +541,6 @@ export interface InteractiveExtension {
       processName: string,
       command: string,
       options?: { alwaysPrintStderr?: boolean }
-    ) => Promise<void>
+    ) => void
   }
 }

--- a/src/recipes/build.ts
+++ b/src/recipes/build.ts
@@ -112,7 +112,7 @@ export const createBuildWorkflows = async (
   const existsIOsDir = toolbox.filesystem.exists('ios')
 
   if (expo) {
-    await toolbox.expo.prebuild(context, { cleanAfter: false })
+    toolbox.expo.prebuild(context, { cleanAfter: false })
   }
 
   const iOSAppName = toolbox.filesystem

--- a/src/recipes/eas.ts
+++ b/src/recipes/eas.ts
@@ -74,16 +74,16 @@ const execute = async (
   await toolbox.dependencies.add('expo-updates', context)
 
   if (!toolbox.filesystem.exists('eas.json')) {
-    await toolbox.expo.eas.buildConfigure()
+    toolbox.expo.eas.buildConfigure()
   } else {
     toolbox.interactive.step(
       'Detected eas.json file, skipping EAS Build configuration.'
     )
   }
 
-  await toolbox.expo.prebuild(context, { cleanAfter: true })
+  toolbox.expo.prebuild(context, { cleanAfter: true })
 
-  await toolbox.expo.eas.credentialsConfigureBuild({
+  toolbox.expo.eas.credentialsConfigureBuild({
     platform: 'android',
     environment: 'development',
   })
@@ -101,13 +101,13 @@ const execute = async (
   )
 
   if (withIOSCredentials) {
-    await toolbox.expo.eas.credentialsConfigureBuild({
+    toolbox.expo.eas.credentialsConfigureBuild({
       platform: 'ios',
       environment: 'development',
     })
   }
 
-  await toolbox.expo.eas.updateConfigure()
+  toolbox.expo.eas.updateConfigure()
 
   await patchEasJson(toolbox, withIOSCredentials)
   await patchAppJson(toolbox)


### PR DESCRIPTION
## Why

There is a problem when running `npx setup-ci` without `--preset` flag, after the clack multiselect is rendered, all subprocesses spawned with `toolbox.interactive.spawnSubprocess()` have flaky stdin - not all keystrokes seem to be registered. This resulted in a problem where confirm prompts in subprocesses required 3-4 or more "Enter" clicks to register.

## Root cause

unknown

## Fix

Spawning the subprocess using `execSync` instead of `spawn` fixes the issue.