### PR TITLE
fix: ios app name resolution on linux

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   jest:
     name: Jest
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -111,6 +111,8 @@ export const setupTestProject = (projectName: string): void => {
       )} ${PATH_TO_TEST_PROJECT}`,
       `cd ${PATH_TO_TEST_PROJECT}`,
       'git init',
+      'git config --local user.email "email"',
+      'git config --local user.name "name"',
       'git add .',
       'git commit -m "Initial commit"',
     ].join(' && ')

--- a/src/recipes/build.ts
+++ b/src/recipes/build.ts
@@ -117,12 +117,12 @@ export const createBuildWorkflows = async (
 
   const iOSAppName = toolbox.filesystem
     .list('ios')
-    ?.find((file) => file.endsWith('.xcworkspace'))
-    ?.replace('.xcworkspace', '')
+    ?.find((file) => file.endsWith('.xcodeproj'))
+    ?.replace('.xcodeproj', '')
 
   if (!iOSAppName) {
     throw CycliError(
-      'Failed to obtain iOS app name. Perhaps your ios/ directory is missing .xcworkspace file.'
+      'Failed to obtain iOS app name. Perhaps your ios/ directory is missing *.xcodeproj file.'
     )
   }
 


### PR DESCRIPTION
## Why

`npx expo prebuild` on linux generates `ios/` directory without `{iOSProjectName}.xcworkspace`.

When running `npx expo prebuild && ls -al ios | awk -F' ' '{print $NF}'` in expo project, the results are:

#### macos
```
.gitignore
.xcode.env
.xcode.env.local
Podfile
Podfile.lock
Podfile.properties.json
Pods
build
{iOSProjectName}
{iOSProjectName}.xcodeproj
{iOSProjectName}.xcworkspace
```

#### linux
```
.gitignore
.xcode.env
Podfile
Podfile.properties.json
{iOSProjectName}
{iOSProjectName}.xcodeproj
```

## Solution

Evaluate `iOSAppName` based on `ios/*.xcodeproj` instead of `ios/*.xcworkspace`.

## Other changes

Change jest workflow runner from `macos-latest` to `ubuntu-latest`.