### PR TITLE
feat: add telemetry

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -64,11 +64,14 @@ export const cli = async (
   }
 ): Promise<string> => {
   const subprocessPromise = new Promise<string>((resolve, reject) => {
-    const subprocess = spawn(`node ${PATH_TO_BINARY} ${flags.join(' ')}`, {
-      shell: true,
-      cwd,
-      stdio: ['inherit', 'pipe', 'inherit'],
-    })
+    const subprocess = spawn(
+      `node ${PATH_TO_BINARY} --skip-telemetry ${flags.join(' ')}`,
+      {
+        shell: true,
+        cwd,
+        stdio: ['inherit', 'pipe', 'inherit'],
+      }
+    )
 
     let output = ''
 

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ When using `npx setup-ci`, you can provide additional flags to modify its defaul
     <td style="vertical-align: middle;">--skip-git-check</td>
     <td style="vertical-align: middle;">By default, the script will prompt the user if there are uncommitted changes in the working repository. Use this flag to proceed without asking.</td>
   </tr>
+  <tr>
+    <td style="vertical-align: middle;">--skip-telemetry</td>
+    <td style="vertical-align: middle;">Skip sending anonymous metrics.</td>
+  </tr>
 </table>
 
 The following are **feature flags** that can be used with `--preset` flag (they are ignored if `--preset` is not provided).
@@ -124,6 +128,10 @@ as you will always be prompted to create secrets if necessary. The following tab
 ## 🔍 Troubleshooting 
 
 For known issues with `npx setup-ci`, please check [Troubleshooting](docs/troubleshooting.md).
+
+## 📊 Metrics
+
+By default, `npx setup-ci` collects anonymous usage data that helps us improve the tool. You can disable it by using the `--skip-telemetry` option. Collected data consists of timestamp, tool version, selected options, whether the script has been run for the first time and whether it ended with an unexpected error.
 
 ## 💬 Your feedback
 

--- a/readme.md
+++ b/readme.md
@@ -125,13 +125,15 @@ as you will always be prompted to create secrets if necessary. The following tab
   </tr>
 </table>
 
-## 🔍 Troubleshooting 
+## 🔍 Troubleshooting
 
 For known issues with `npx setup-ci`, please check [Troubleshooting](docs/troubleshooting.md).
 
 ## 📊 Metrics
 
-By default, `npx setup-ci` collects anonymous usage data that helps us improve the tool. You can disable it by using the `--skip-telemetry` option. Collected data consists of timestamp, tool version, selected options, whether the script has been run for the first time and whether it ended with an unexpected error.
+By default, `npx setup-ci` collects anonymous usage data that helps us improve the tool. You can disable it by using the `--skip-telemetry` option.
+Collected data consists of timestamp, tool version, selected options, whether the script has been run for the first time and whether it ended with an unexpected error (without stacktrace
+so that no sensitive PII can be accidentally leaked).
 
 ## 💬 Your feedback
 

--- a/src/commands/setup-ci.ts
+++ b/src/commands/setup-ci.ts
@@ -15,6 +15,7 @@ import {
   HELP_FLAG,
   PRESET_FLAG,
   REPOSITORY_FEATURES_HELP_URL,
+  REPOSITORY_METRICS_HELP_URL,
   REPOSITORY_TROUBLESHOOTING_URL,
   SKIP_TELEMETRY_FLAG,
 } from '../constants'
@@ -186,7 +187,7 @@ const run = async (toolbox: CycliToolbox) => {
     toolbox.interactive.surveyInfo(
       [
         `${CYCLI_COMMAND} collects anonymous usage data. You can disable it by using --skip-telemetry.`,
-        'Learn more at [TODO]',
+        `Learn more at ${REPOSITORY_METRICS_HELP_URL}`,
       ].join('\n'),
       'dim'
     )

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,7 @@ export const S_R_ARROW = '►'
 export const NON_INTERACTIVE_FLAG = 'non-interactive'
 export const HELP_FLAG = 'help'
 export const PRESET_FLAG = 'preset'
+export const SKIP_TELEMETRY_FLAG = 'skip-telemetry'
 
 export const LOCK_FILE_TO_MANAGER = {
   ['yarn.lock']: 'yarn',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,5 +54,6 @@ export const LOCK_FILE_TO_MANAGER = {
 const REPOSITORY_URL = 'https://github.com/software-mansion/setup-ci'
 export const REPOSITORY_SECRETS_HELP_URL = `${REPOSITORY_URL}?tab=readme-ov-file#-repository-secrets`
 export const REPOSITORY_FEATURES_HELP_URL = `${REPOSITORY_URL}?tab=readme-ov-file#%EF%B8%8F-features`
+export const REPOSITORY_METRICS_HELP_URL = `${REPOSITORY_URL}?tab=readme-ov-file#%-metrics`
 export const REPOSITORY_ISSUES_URL = `${REPOSITORY_URL}/issues`
 export const REPOSITORY_TROUBLESHOOTING_URL = `${REPOSITORY_URL}/blob/master/docs/troubleshooting.md`

--- a/src/extensions/interactive.ts
+++ b/src/extensions/interactive.ts
@@ -388,6 +388,15 @@ module.exports = (toolbox: CycliToolbox) => {
     else print.info(message)
   }
 
+  const surveyInfo = (message: string, color?: MessageColor) => {
+    print.info(
+      `${dim(S_BAR)}\n${dim(S_BAR)}  ${withNewlinePrefix(
+        color ? COLORS[color](message) : message,
+        `${dim(S_BAR)} `
+      )}`
+    )
+  }
+
   const vspace = () => info('')
 
   const step = (message: string) => {
@@ -490,6 +499,7 @@ module.exports = (toolbox: CycliToolbox) => {
     surveyStep,
     surveyWarning,
     info,
+    surveyInfo,
     vspace,
     step,
     error,
@@ -524,6 +534,7 @@ export interface InteractiveExtension {
     surveyStep: (message: string) => void
     surveyWarning: (message: string) => void
     info: (message: string, color?: MessageColor) => void
+    surveyInfo: (message: string, color?: MessageColor) => void
     vspace: () => void
     step: (message: string) => void
     error: (message: string) => void

--- a/src/extensions/options.ts
+++ b/src/extensions/options.ts
@@ -1,4 +1,8 @@
-import { NON_INTERACTIVE_FLAG, PRESET_FLAG } from '../constants'
+import {
+  NON_INTERACTIVE_FLAG,
+  PRESET_FLAG,
+  SKIP_TELEMETRY_FLAG,
+} from '../constants'
 import { CycliToolbox } from '../types'
 
 module.exports = (toolbox: CycliToolbox) => {
@@ -11,10 +15,14 @@ module.exports = (toolbox: CycliToolbox) => {
   const isNonInteractive = () =>
     Boolean(toolbox.parameters.options[NON_INTERACTIVE_FLAG])
 
+  const skipTelemetry = () =>
+    Boolean(toolbox.parameters.options[SKIP_TELEMETRY_FLAG])
+
   toolbox.options = {
     isPreset,
     isRecipeSelected,
     isNonInteractive,
+    skipTelemetry,
   }
 }
 
@@ -23,5 +31,6 @@ export interface OptionsExtension {
     isPreset: () => boolean
     isRecipeSelected: (recipeFlag: string) => boolean
     isNonInteractive: () => boolean
+    skipTelemetry: () => boolean
   }
 }

--- a/src/extensions/projectContext.ts
+++ b/src/extensions/projectContext.ts
@@ -59,7 +59,20 @@ module.exports = (toolbox: CycliToolbox) => {
     return process.cwd()
   }
 
+  // Check whether ~/.setup-ci exists and creates it if not.
+  const isFirstUse = (): boolean => {
+    const setupCiDir = join(filesystem.homedir(), '.setup-ci')
+
+    if (!filesystem.exists(setupCiDir)) {
+      filesystem.write(setupCiDir, '')
+      return true
+    }
+
+    return false
+  }
+
   const obtain = (): ProjectContext => {
+    const firstUse = isFirstUse()
     const repoRoot = getRepoRoot()
     const packageRoot = getPackageRoot()
 
@@ -81,6 +94,7 @@ module.exports = (toolbox: CycliToolbox) => {
         absFromRepoRoot,
       },
       selectedOptions: [],
+      firstUse,
     }
   }
 

--- a/src/extensions/telemetry.ts
+++ b/src/extensions/telemetry.ts
@@ -1,0 +1,42 @@
+import { CycliToolbox } from '../types'
+
+const SUPABASE_BASE_URL = 'https://pjkofjupiymnmxtwqcnx.supabase.co/rest/v1'
+const SUPABASE_PUBLIC_API_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBqa29manVwaXltbm14dHdxY254Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mjc0MjgyNTYsImV4cCI6MjA0MzAwNDI1Nn0.f_YWrcYUQYqrwyT6nIv0w16uKxnOjlp5a93X6eeRv4Q'
+
+interface Log {
+  version: string
+  firstUse?: boolean
+  options?: { [key: string]: boolean }
+  error: boolean
+}
+
+module.exports = (toolbox: CycliToolbox) => {
+  const sendLog = async (log: Log) => {
+    const { version, firstUse, options, error } = log
+
+    const client = toolbox.http.create({
+      baseURL: SUPABASE_BASE_URL,
+      headers: {
+        apiKey: SUPABASE_PUBLIC_API_KEY,
+      },
+    })
+
+    await client.post('/usage', {
+      version,
+      first_use: firstUse,
+      options,
+      error,
+    })
+  }
+
+  toolbox.telemetry = {
+    sendLog,
+  }
+}
+
+export interface TelemetryExtension {
+  telemetry: {
+    sendLog: (log: Log) => Promise<void>
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import { OptionsExtension } from './extensions/options'
 import { FurtherActionsExtension } from './extensions/furtherActions'
 import { ExpoExtension } from './extensions/expo'
 import { PrettierExtension } from './extensions/prettier'
+import { TelemetryExtension } from './extensions/telemetry'
 
 export const CycliError = (message: string): Error => {
   const error = new Error(message)
@@ -84,6 +85,7 @@ export interface ProjectContext {
     absFromRepoRoot: (...p: string[]) => string
   }
   selectedOptions: string[]
+  firstUse: boolean
 }
 
 export type CycliToolbox = {
@@ -100,4 +102,5 @@ export type CycliToolbox = {
   DiffExtension &
   FurtherActionsExtension &
   ExpoExtension &
-  PrettierExtension
+  PrettierExtension &
+  TelemetryExtension


### PR DESCRIPTION
Resolves #121 

We start will collecting the following data:

```
{
    version: string,
    first_use: boolean,
    options: {
        lint: boolean,
        test: boolean,
        ts: boolean,
        prettier: boolean,
        eas: boolean,
        detox: boolean,
        maestro: boolean    
    },
    error: boolean
}
```

This is how printed log looks like:

![Zrzut ekranu 2024-10-2 o 11 45 24](https://github.com/user-attachments/assets/ad23e80f-dfac-43a0-a38c-7c15fc8b3288)
