### PR TITLE
feat: make adding deps independent from gluegun

### DIFF
--- a/__tests__/recipes/__snapshots__/detox.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/detox.test.ts.snap
@@ -1107,7 +1107,8 @@ jobs:
           gradle-version: 8.8
 
       - name: 🛠️ Build
-        run: npm run build:release:android --prefix apps/expo-app
+        run: npm run build:release:android
+        working-directory: apps/expo-app
 
       - name: 📁 Prepare cache folder
         run: |
@@ -1169,7 +1170,8 @@ jobs:
           xcode-version: latest-stable
 
       - name: 🛠️ Build
-        run: npm run build:release:ios --prefix apps/expo-app
+        run: npm run build:release:ios
+        working-directory: apps/expo-app
 
       - name: 📁 Prepare cache folder
         run: |
@@ -1272,7 +1274,8 @@ jobs:
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           avd-name: e2e_emulator
           arch: x86_64
-          script: npm run detox:test:android --prefix apps/expo-app
+          script: npm run detox:test:android
+          working-directory: apps/expo-app
 "
 `;
 
@@ -1330,7 +1333,8 @@ jobs:
         run: mv ios-release-build apps/expo-app/ios-release-build
 
       - name: 📋 Run Detox tests
-        run: npm run detox:test:ios --prefix apps/expo-app
+        run: npm run detox:test:ios
+        working-directory: apps/expo-app
 "
 `;
 
@@ -1527,7 +1531,7 @@ jobs:
           gradle-version: 8.8
 
       - name: 🛠️ Build
-        run: yarn build:release:android
+        run: yarn run build:release:android
 
       - name: 📁 Prepare cache folder
         run: |
@@ -1587,7 +1591,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: 🛠️ Build
-        run: yarn build:release:ios
+        run: yarn run build:release:ios
 
       - name: 📁 Prepare cache folder
         run: |
@@ -1685,7 +1689,7 @@ jobs:
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           avd-name: e2e_emulator
           arch: x86_64
-          script: yarn detox:test:android
+          script: yarn run detox:test:android
 "
 `;
 
@@ -1738,7 +1742,7 @@ jobs:
           key: ios-release-build-\${{ github.event.pull_request.head.sha }}
 
       - name: 📋 Run Detox tests
-        run: yarn detox:test:ios
+        run: yarn run detox:test:ios
 "
 `;
 
@@ -1994,7 +1998,8 @@ jobs:
           gradle-version: 8.8
 
       - name: 🛠️ Build
-        run: yarn --cwd apps/expo-app build:release:android
+        run: yarn run build:release:android
+        working-directory: apps/expo-app
 
       - name: 📁 Prepare cache folder
         run: |
@@ -2056,7 +2061,8 @@ jobs:
           xcode-version: latest-stable
 
       - name: 🛠️ Build
-        run: yarn --cwd apps/expo-app build:release:ios
+        run: yarn run build:release:ios
+        working-directory: apps/expo-app
 
       - name: 📁 Prepare cache folder
         run: |
@@ -2159,7 +2165,8 @@ jobs:
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           avd-name: e2e_emulator
           arch: x86_64
-          script: yarn --cwd apps/expo-app detox:test:android
+          script: yarn run detox:test:android
+          working-directory: apps/expo-app
 "
 `;
 
@@ -2217,6 +2224,7 @@ jobs:
         run: mv ios-release-build apps/expo-app/ios-release-build
 
       - name: 📋 Run Detox tests
-        run: yarn --cwd apps/expo-app detox:test:ios
+        run: yarn run detox:test:ios
+        working-directory: apps/expo-app
 "
 `;

--- a/__tests__/recipes/__snapshots__/jest.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/jest.test.ts.snap
@@ -221,7 +221,8 @@ jobs:
         run: npm ci
 
       - name: 🎭 Run Jest
-        run: npm run test --prefix apps/expo-app
+        run: npm run test
+        working-directory: apps/expo-app
 "
 `;
 
@@ -291,7 +292,7 @@ jobs:
         run: yarn install --immutable
 
       - name: 🎭 Run Jest
-        run: yarn test
+        run: yarn run test
 "
 `;
 
@@ -376,6 +377,7 @@ jobs:
         run: yarn install --immutable
 
       - name: 🎭 Run Jest
-        run: yarn --cwd apps/expo-app test
+        run: yarn run test
+        working-directory: apps/expo-app
 "
 `;

--- a/__tests__/recipes/__snapshots__/lint.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/lint.test.ts.snap
@@ -219,7 +219,8 @@ jobs:
         run: npm ci
 
       - name: 🤓 Run ESLint
-        run: npm run lint --prefix apps/expo-app
+        run: npm run lint
+        working-directory: apps/expo-app
 "
 `;
 
@@ -299,7 +300,7 @@ jobs:
         run: yarn install --immutable
 
       - name: 🤓 Run ESLint
-        run: yarn lint
+        run: yarn run lint
 "
 `;
 
@@ -394,7 +395,8 @@ jobs:
         run: yarn install --immutable
 
       - name: 🤓 Run ESLint
-        run: yarn --cwd apps/expo-app lint
+        run: yarn run lint
+        working-directory: apps/expo-app
 "
 `;
 

--- a/__tests__/recipes/__snapshots__/prettier.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/prettier.test.ts.snap
@@ -216,7 +216,8 @@ jobs:
         run: npm ci
 
       - name: ✨ Run Prettier check
-        run: npm run prettier:check --prefix apps/expo-app
+        run: npm run prettier:check
+        working-directory: apps/expo-app
 "
 `;
 
@@ -295,7 +296,7 @@ jobs:
         run: yarn install --immutable
 
       - name: ✨ Run Prettier check
-        run: yarn prettier:check
+        run: yarn run prettier:check
 "
 `;
 
@@ -389,7 +390,8 @@ jobs:
         run: yarn install --immutable
 
       - name: ✨ Run Prettier check
-        run: yarn --cwd apps/expo-app prettier:check
+        run: yarn run prettier:check
+        working-directory: apps/expo-app
 "
 `;
 

--- a/__tests__/recipes/__snapshots__/typescript.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/typescript.test.ts.snap
@@ -234,7 +234,8 @@ jobs:
         run: npm ci
 
       - name: 🔍 Run Typescript check
-        run: npm run ts:check --prefix apps/expo-app
+        run: npm run ts:check
+        working-directory: apps/expo-app
 "
 `;
 
@@ -303,7 +304,7 @@ jobs:
         run: yarn install --immutable
 
       - name: 🔍 Run Typescript check
-        run: yarn ts:check
+        run: yarn run ts:check
 "
 `;
 
@@ -394,6 +395,7 @@ jobs:
         run: yarn install --immutable
 
       - name: 🔍 Run Typescript check
-        run: yarn --cwd apps/expo-app ts:check
+        run: yarn run ts:check
+        working-directory: apps/expo-app
 "
 `;

--- a/src/templates/build-debug/build-debug-android.ejf
+++ b/src/templates/build-debug/build-debug-android.ejf
@@ -5,11 +5,6 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const build = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:debug:android`,
-  npm: `npm run build:debug:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Build Android Debug App
@@ -69,7 +64,9 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: 🛠️ Build
-        run: <%= build[props.packageManager] %>
+        run: <%= props.packageManager %> run build:debug:android
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 📁 Prepare cache folder
         run: |

--- a/src/templates/build-debug/build-debug-ios.ejf
+++ b/src/templates/build-debug/build-debug-ios.ejf
@@ -5,11 +5,6 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const build = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:debug:ios`,
-  npm: `npm run build:debug:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Build iOS Debug App
@@ -55,7 +50,9 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: 🛠️ Build
-        run: <%= build[props.packageManager] %>
+        run: <%= props.packageManager %> run build:debug:ios
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 📁 Prepare cache folder
         run: |

--- a/src/templates/build-debug/lookup-cached-debug-build.ejf
+++ b/src/templates/build-debug/lookup-cached-debug-build.ejf
@@ -6,10 +6,7 @@ const install = {
   npm: "npm ci"
 }
 
-const runFingerprint = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}` + 'fingerprint:${{ inputs.platform }}',
-  npm: 'npm run fingerprint:${{ inputs.platform }}' + ((isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : "")
-}
+const fingerprintScript = 'fingerprint:${{ inputs.platform }}'
 %>
 
 name: Lookup Cached Debug Build
@@ -61,10 +58,12 @@ jobs:
       - name: 🧬 Calculate fingerprint
         id: fingerprint
         run: |
-          FINGERPRINT=$(<%= runFingerprint[props.packageManager] %> | grep '^fingerprint:' | cut -d ' ' -f2-)
+          FINGERPRINT=$(<%= props.packageManager %> run <%= fingerprintScript %> | grep '^fingerprint:' | cut -d ' ' -f2-)
           echo "Fingerprint for ${{ inputs.platform }}: $FINGERPRINT"
           echo "FINGERPRINT=$FINGERPRINT" >> $GITHUB_ENV
           echo "fingerprint=$FINGERPRINT" >> $GITHUB_OUTPUT
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 🐛 Try to restore build from cache
         id: debug-build-restore

--- a/src/templates/build-release/build-release-android.ejf
+++ b/src/templates/build-release/build-release-android.ejf
@@ -5,11 +5,6 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const build = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:android`,
-  npm: `npm run build:release:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Build Android Release App
@@ -70,7 +65,9 @@ jobs:
           gradle-version: 8.8
 
       - name: 🛠️ Build
-        run: <%= build[props.packageManager] %>
+        run: <%= props.packageManager %> run build:release:android
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 📁 Prepare cache folder 
         run: |

--- a/src/templates/build-release/build-release-ios.ejf
+++ b/src/templates/build-release/build-release-ios.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const build = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}build:release:ios`,
-  npm: `npm run build:release:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Build iOS Release App
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -56,7 +51,9 @@ jobs:
           xcode-version: latest-stable
 
       - name: 🛠️ Build
-        run: <%= build[props.packageManager] %>
+        run: <%= props.packageManager %> run build:release:ios
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 📁 Prepare cache folder 
         run: |

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const runTests = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:android`,
-  npm: `npm run detox:test:android ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Test Detox Android
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -99,4 +94,6 @@ jobs:
           emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
           avd-name: e2e_emulator
           arch: x86_64
-          script: <%= runTests[props.packageManager] %>
+          script: <%= props.packageManager %> run detox:test:android
+          <%= (isMonorepo) ?
+            `working-directory: ${props.pathRelativeToRoot}` : "" %>

--- a/src/templates/detox/test-detox-ios.ejf
+++ b/src/templates/detox/test-detox-ios.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const runTests = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}detox:test:ios`,
-  npm: `npm run detox:test:ios ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Test Detox iOS
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -66,4 +61,6 @@ jobs:
         run: mv ios-release-build ${props.pathRelativeToRoot}/ios-release-build` : "" %>
 
       - name: 📋 Run Detox tests
-        run: <%= runTests[props.packageManager] %>
+        run: <%= props.packageManager %> run detox:test:ios
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>

--- a/src/templates/eas/eas.ejf
+++ b/src/templates/eas/eas.ejf
@@ -55,4 +55,5 @@ jobs:
         with:
           profile: development
           branch: development
-          <%= (isMonorepo) ? `working-directory: ${props.pathRelativeToRoot}` : '' %>
+          <%= (isMonorepo) ? 
+            `working-directory: ${props.pathRelativeToRoot}` : '' %>

--- a/src/templates/jest/jest.ejf
+++ b/src/templates/jest/jest.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const run = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}test`,
-  npm: `npm run test ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Run Jest tests
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -37,4 +32,6 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: 🎭 Run Jest
-        run: <%= run[props.packageManager] %>
+        run: <%= props.packageManager %> run test
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>

--- a/src/templates/lint/lint.ejf
+++ b/src/templates/lint/lint.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const run = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}lint`,
-  npm: `npm run lint ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Check ESLint
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
  
@@ -37,4 +32,6 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: 🤓 Run ESLint
-        run: <%= run[props.packageManager] %>
+        run: <%= props.packageManager %> run lint
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>

--- a/src/templates/maestro/maestro-test-android.ejf
+++ b/src/templates/maestro/maestro-test-android.ejf
@@ -10,17 +10,12 @@ const startBundler = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}start`,
   npm: `npm run start ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
 }
-
-const runTests = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}maestro:test`,
-  npm: `npm run maestro:test ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Maestro Test Android
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -144,7 +139,9 @@ jobs:
           arch: x86_64
           script: |
             adb install android-debug-build/android-debug.apk
-            <%= runTests[props.packageManager] %>
+            <%= props.packageManager %> run maestro:test
+          <%= (isMonorepo) ?
+            `working-directory: ${props.pathRelativeToRoot}` : "" %>
         env:
           MAESTRO_DRIVER_STARTUP_TIMEOUT: 120000
 

--- a/src/templates/maestro/maestro-test-ios.ejf
+++ b/src/templates/maestro/maestro-test-ios.ejf
@@ -10,17 +10,12 @@ const startBundler = {
   yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}start`,
   npm: `npm run start ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
 }
-
-const runTests = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}maestro:test`,
-  npm: `npm run maestro:test ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Maestro Test iOS
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -125,9 +120,11 @@ jobs:
       - name: 🧪 Run Maestro tests
         run: |
           xcrun simctl install booted ios-debug-build/ios-debug.app
-          <%= runTests[props.packageManager] %>
+          <%= props.packageManager %> run maestro:test
         env:
           MAESTRO_DRIVER_STARTUP_TIMEOUT: 120000
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>
 
       - name: 📤 Store debug output if failed
         if: failure()

--- a/src/templates/prettier/prettier.ejf
+++ b/src/templates/prettier/prettier.ejf
@@ -5,11 +5,6 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const run = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}prettier:check`,
-  npm: `npm run prettier:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Prettier check
@@ -37,4 +32,6 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: ✨ Run Prettier check
-        run: <%= run[props.packageManager] %>
+        run: <%= props.packageManager %> run prettier:check
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>

--- a/src/templates/typescript/typescript.ejf
+++ b/src/templates/typescript/typescript.ejf
@@ -5,17 +5,12 @@ const install = {
   yarn: "yarn install --immutable",
   npm: "npm ci"
 }
-
-const run = {
-  yarn: `yarn ${(isMonorepo) ? `--cwd ${props.pathRelativeToRoot} ` : ""}ts:check`,
-  npm: `npm run ts:check ${(isMonorepo) ? `--prefix ${props.pathRelativeToRoot}` : ""}`
-}
 %>
 
 name: Run Typescript
 
 on:
-  pull_request: <%= (props.pathRelativeToRoot !== '.') ? `
+  pull_request: <%= (isMonorepo) ? `
     paths:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
@@ -37,4 +32,6 @@ jobs:
         run: <%= install[props.packageManager] %>
 
       - name: 🔍 Run Typescript check
-        run: <%= run[props.packageManager] %>
+        run: <%= props.packageManager %> run ts:check
+        <%= (isMonorepo) ?
+          `working-directory: ${props.pathRelativeToRoot}` : "" %>


### PR DESCRIPTION
## Description

This is the first step of support for `bun` and `pnpm`. We want to be independent from `gluegun` in terms of installing dependencies as it does not support `bun` nor `pnpm`.

## Changes

- running install commands for `npm` and `yarn` on our own instead of using `toolbox.packageManager.add`
- changed `run` commands in generated workflows to use `working-directory` instead of package manager specific flags like `--cwd` or `--prefix`, this will make implementing support for new package managers easier