### PR TITLE
feat: create expo specific config for lint in expo projects

### DIFF
--- a/__tests__/recipes/__snapshots__/lint.test.ts.snap
+++ b/__tests__/recipes/__snapshots__/lint.test.ts.snap
@@ -172,11 +172,10 @@ Object {
   },
   "devDependencies": Object {
     "@babel/core": "",
-    "@react-native/eslint-config": "",
     "@types/react": "",
     "@types/react-test-renderer": "",
     "eslint": "",
-    "eslint-plugin-ft-flow": "",
+    "eslint-config-expo": "",
     "jest-expo": "",
     "react-test-renderer": "",
     "typescript": "",
@@ -229,16 +228,7 @@ jobs:
 
 exports[`lint recipe rn-setup-ci-npm-monorepo lint 3`] = `
 "{
-  \\"parserOptions\\": {
-    \\"ecmaVersion\\": \\"2020\\",
-    \\"sourceType\\": \\"module\\"
-  },
-  \\"extends\\": [\\"@react-native\\", \\"eslint:recommended\\"],
-  \\"env\\": {
-    \\"browser\\": true,
-    \\"node\\": true
-  },
-  \\"rules\\": {}
+  \\"extends\\": \\"expo\\"
 }
 "
 `;
@@ -350,11 +340,10 @@ Object {
   },
   "devDependencies": Object {
     "@babel/core": "",
-    "@react-native/eslint-config": "",
     "@types/react": "",
     "@types/react-test-renderer": "",
     "eslint": "",
-    "eslint-plugin-ft-flow": "",
+    "eslint-config-expo": "",
     "jest-expo": "",
     "react-test-renderer": "",
     "typescript": "",
@@ -407,16 +396,7 @@ jobs:
 
 exports[`lint recipe rn-setup-ci-yarn-monorepo lint 3`] = `
 "{
-  \\"parserOptions\\": {
-    \\"ecmaVersion\\": \\"2020\\",
-    \\"sourceType\\": \\"module\\"
-  },
-  \\"extends\\": [\\"@react-native\\", \\"eslint:recommended\\"],
-  \\"env\\": {
-    \\"browser\\": true,
-    \\"node\\": true
-  },
-  \\"rules\\": {}
+  \\"extends\\": \\"expo\\"
 }
 "
 `;

--- a/src/templates/lint/.eslintrc-expo.json.ejs
+++ b/src/templates/lint/.eslintrc-expo.json.ejs
@@ -1,0 +1,3 @@
+{
+  extends: 'expo'
+}


### PR DESCRIPTION
Resolves #134 

## Changes

- install `eslint-config-expo` instead of `@react-native/eslint-config` in expo projects when lint recipe is selected