### PR TITLE
feat: stop using prebuild in eas preview recipe

### DIFF
--- a/src/extensions/expo.ts
+++ b/src/extensions/expo.ts
@@ -1,7 +1,8 @@
+import { execSync } from 'child_process'
 import { CycliToolbox, ProjectContext, Platform, Environment } from '../types'
 
 module.exports = (toolbox: CycliToolbox) => {
-  const prebuild = (
+  const prebuild = async (
     context: ProjectContext,
     { cleanAfter }: { cleanAfter: boolean }
   ) => {
@@ -10,7 +11,7 @@ module.exports = (toolbox: CycliToolbox) => {
 
     toolbox.print.info('⚙️ Running expo prebuild to setup app configuration.')
 
-    toolbox.interactive.spawnSubprocess(
+    await toolbox.interactive.spawnSubprocess(
       'Expo prebuild',
       `npx expo prebuild --${context.packageManager}`,
       { alwaysPrintStderr: true }
@@ -23,24 +24,46 @@ module.exports = (toolbox: CycliToolbox) => {
   }
 
   const buildConfigure = async (): Promise<void> => {
-    toolbox.interactive.spawnSubprocess(
+    await toolbox.interactive.spawnSubprocess(
       'EAS Build configuration',
-      'npx eas-cli build:configure -p all'
+      'npx eas-cli build:configure -p all',
+      {
+        onError: async () => {
+          await toolbox.interactive.actionPrompt(
+            [
+              'EAS Build configuration failed. If the reason is missing configuration in dynamic file,',
+              'please update it manually before proceeding.\n',
+            ].join(' ')
+          )
+          return true
+        },
+      }
     )
 
     toolbox.interactive.step('Created default EAS Build configuration.')
   }
 
   const updateConfigure = async () => {
-    toolbox.interactive.spawnSubprocess(
+    await toolbox.interactive.spawnSubprocess(
       'EAS Update configuration',
-      'npx eas-cli update:configure'
+      'npx eas-cli update:configure',
+      {
+        onError: async () => {
+          await toolbox.interactive.actionPrompt(
+            [
+              'EAS Update configuration failed. If the reason is missing configuration in dynamic file,',
+              'please update it manually before proceeding.\n',
+            ].join(' ')
+          )
+          return true
+        },
+      }
     )
 
     toolbox.interactive.step('Created default EAS Update configuration.')
   }
 
-  const credentialsConfigureBuild = ({
+  const credentialsConfigureBuild = async ({
     platform,
     environment,
   }: {
@@ -49,7 +72,7 @@ module.exports = (toolbox: CycliToolbox) => {
   }) => {
     const platformName = platform === 'android' ? 'Android' : 'iOS'
 
-    toolbox.interactive.spawnSubprocess(
+    await toolbox.interactive.spawnSubprocess(
       `EAS Credentials configuration for ${platformName}`,
       `npx eas-cli credentials:configure-build -p ${platform} -e ${environment}`
     )
@@ -57,9 +80,42 @@ module.exports = (toolbox: CycliToolbox) => {
     toolbox.interactive.step(`Configured EAS Credentials for ${platformName}.`)
   }
 
+  const login = async (): Promise<void> => {
+    await toolbox.interactive.spawnSubprocess('EAS Login', 'npx eas-cli login')
+    toolbox.interactive.step(`Successfully logged in to EAS.`)
+  }
+
+  const whoami = (): string | undefined => {
+    let username: string | undefined = undefined
+
+    try {
+      username = execSync('npx eas-cli whoami', {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .toString()
+        .trim()
+    } catch (error: unknown) {}
+
+    return username
+  }
+
+  const whoamiWithForcedLogin = async (): Promise<string | undefined> => {
+    const username = whoami()
+
+    if (!username) {
+      await login()
+      return whoami()
+    }
+
+    return username
+  }
+
   toolbox.expo = {
     prebuild,
     eas: {
+      login,
+      whoami,
+      whoamiWithForcedLogin,
       buildConfigure,
       updateConfigure,
       credentialsConfigureBuild,
@@ -74,15 +130,18 @@ export interface ExpoExtension {
       { cleanAfter }: { cleanAfter: boolean }
     ) => void
     eas: {
-      buildConfigure: () => void
-      updateConfigure: () => void
+      login: () => Promise<void>
+      whoami: () => string | undefined
+      whoamiWithForcedLogin: () => Promise<string | undefined>
+      buildConfigure: () => Promise<void>
+      updateConfigure: () => Promise<void>
       credentialsConfigureBuild: ({
         platform,
         environment,
       }: {
         platform: Platform
         environment: Environment
-      }) => void
+      }) => Promise<void>
     }
   }
 }

--- a/src/extensions/expo.ts
+++ b/src/extensions/expo.ts
@@ -128,7 +128,7 @@ export interface ExpoExtension {
     prebuild: (
       context: ProjectContext,
       { cleanAfter }: { cleanAfter: boolean }
-    ) => void
+    ) => Promise<void>
     eas: {
       login: () => Promise<void>
       whoami: () => string | undefined

--- a/src/extensions/projectConfig.ts
+++ b/src/extensions/projectConfig.ts
@@ -240,6 +240,7 @@ module.exports = (toolbox: CycliToolbox) => {
     packageJson,
     appJsonFile,
     appJson,
+    appJs,
     patchAppConfig,
     nodeVersionFile,
     isExpo,
@@ -254,6 +255,7 @@ export interface ProjectConfigExtension {
     packageJson: () => PackageJson
     appJsonFile: () => string | undefined
     appJson: () => AppJson | undefined
+    appJs: () => string | undefined
     patchAppConfig: (
       patch: Record<string, unknown>,
       allowChangeAfterScript?: boolean

--- a/src/extensions/projectConfig.ts
+++ b/src/extensions/projectConfig.ts
@@ -6,8 +6,11 @@ import {
   ProjectContext,
 } from '../types'
 import { join } from 'path'
+import { recursiveAssign } from '../utils/recursiveAssign'
 
 const APP_JSON_FILES = ['app.json', 'app.config.json']
+const APP_JS_FILES = ['app.js', 'app.config.js']
+
 const DEFAULT_NODE_VERSION = 'v20.17.0'
 
 module.exports = (toolbox: CycliToolbox) => {
@@ -27,6 +30,10 @@ module.exports = (toolbox: CycliToolbox) => {
     return APP_JSON_FILES.find((file) => filesystem.exists(file))
   }
 
+  const appJsFile = (): string | undefined => {
+    return APP_JS_FILES.find((file) => filesystem.exists(file))
+  }
+
   const appJson = (): AppJson | undefined => {
     const file = appJsonFile()
 
@@ -35,6 +42,53 @@ module.exports = (toolbox: CycliToolbox) => {
     }
 
     return undefined
+  }
+
+  const appJs = (): string | undefined => {
+    const file = appJsFile()
+
+    if (file) {
+      return filesystem.read(file)
+    }
+
+    return undefined
+  }
+
+  const patchAppConfig = async (
+    patch: Record<string, unknown>,
+    allowChangeAfterScript = true
+  ): Promise<void> => {
+    const configFile = appJsonFile()
+
+    if (!configFile) {
+      const dynamicConfigFile = appJsFile()
+      const prettyPatch = JSON.stringify(patch, null, 2)
+
+      let actionPromptMessage =
+        'Cannot write to dynamic config. ' +
+        `Please update ${dynamicConfigFile} with the following values:` +
+        `\n\n${prettyPatch}\n\n`
+
+      if (allowChangeAfterScript) {
+        actionPromptMessage +=
+          'You can do it now or after the script finishes.\n'
+      } else {
+        actionPromptMessage += 'Please do it before proceeding.\n'
+      }
+
+      await toolbox.interactive.actionPrompt(actionPromptMessage)
+
+      if (allowChangeAfterScript) {
+        toolbox.furtherActions.push(
+          `Update ${dynamicConfigFile} with` + `\n\n${prettyPatch}`
+        )
+      }
+    } else {
+      await toolbox.patching.update(
+        configFile,
+        (config: Record<string, unknown>) => recursiveAssign(config, patch)
+      )
+    }
   }
 
   const nodeVersionFileInDirectory = (dir: string): string | undefined => {
@@ -88,12 +142,10 @@ module.exports = (toolbox: CycliToolbox) => {
       return true
     }
 
-    if (filesystem.exists('app.config.js')) {
-      const appJs = filesystem.read('app.config.js')
+    const dynamicAppConfig = appJs()
 
-      if (appJs?.includes('expo:')) {
-        return true
-      }
+    if (dynamicAppConfig?.includes('expo:')) {
+      return true
     }
 
     return false
@@ -121,14 +173,79 @@ module.exports = (toolbox: CycliToolbox) => {
     return appId
   }
 
+  const validateAppName = (name: string): string | void => {
+    if (name.length === 0) {
+      return 'App name cannot be empty'
+    }
+    if (!name.match(/^[a-zA-Z]/)) {
+      return 'App name must start with a letter'
+    }
+    if (!name.match(/^[\w_\.]*$/)) {
+      return 'App name can consist only of alphanumeric characters, dots and underscores'
+    }
+    if (name.match(/\.[0-9_]/) || name[name.length - 1] === '.') {
+      return 'Each dot must be followed by a letter'
+    }
+  }
+
+  // Check if android package name and iOS bundle identifier is defined in app.json/js expo field.
+  // If not, prompt user to define them.
+  const checkAppNameInConfigOrGenerate = async (): Promise<void> => {
+    const isAndroidPackageNameDefined =
+      appJson()?.expo?.android?.package ||
+      appJs()?.match(/android:[\s\S]*package:/)
+
+    const isIOSBundleIdentifierDefined =
+      appJson()?.expo?.ios?.bundleIdentifier ||
+      appJs()?.match(/ios:[\s\S]*bundleIdentifier:/)
+
+    if (!isAndroidPackageNameDefined || !isIOSBundleIdentifierDefined) {
+      const suggestedAppName = [
+        'com',
+        (await toolbox.expo.eas.whoamiWithForcedLogin()) ?? 'yourusername',
+        appJson()?.expo?.slug ?? getName(),
+      ]
+        .join('.')
+        .replace(/-/g, '')
+
+      const patch = { expo: {} }
+
+      if (!isAndroidPackageNameDefined) {
+        const packageName = await toolbox.interactive.textInput(
+          'What would you like your Android package name to be?',
+          suggestedAppName,
+          suggestedAppName,
+          validateAppName
+        )
+
+        patch.expo['android'] = { package: packageName }
+      }
+
+      if (!isIOSBundleIdentifierDefined) {
+        const bundleIdentifier = await toolbox.interactive.textInput(
+          'What would you like your iOS bundle identifier to be?',
+          suggestedAppName,
+          suggestedAppName,
+          validateAppName
+        )
+
+        patch.expo['ios'] = { bundleIdentifier }
+      }
+
+      await patchAppConfig(patch, false)
+    }
+  }
+
   toolbox.projectConfig = {
     packageJson,
     appJsonFile,
     appJson,
+    patchAppConfig,
     nodeVersionFile,
     isExpo,
     getName,
     getAppId,
+    checkAppNameInConfigOrGenerate,
   }
 }
 
@@ -137,9 +254,14 @@ export interface ProjectConfigExtension {
     packageJson: () => PackageJson
     appJsonFile: () => string | undefined
     appJson: () => AppJson | undefined
+    patchAppConfig: (
+      patch: Record<string, unknown>,
+      allowChangeAfterScript?: boolean
+    ) => Promise<void>
     nodeVersionFile: (context: ProjectContext) => string
     isExpo: () => boolean
     getName: () => string
     getAppId: () => string | undefined
+    checkAppNameInConfigOrGenerate: () => Promise<void>
   }
 }

--- a/src/recipes/build.ts
+++ b/src/recipes/build.ts
@@ -112,7 +112,8 @@ export const createBuildWorkflows = async (
   const existsIOsDir = toolbox.filesystem.exists('ios')
 
   if (expo) {
-    toolbox.expo.prebuild(context, { cleanAfter: false })
+    await toolbox.projectConfig.checkAppNameInConfigOrGenerate()
+    await toolbox.expo.prebuild(context, { cleanAfter: false })
   }
 
   const iOSAppName = toolbox.filesystem

--- a/src/recipes/detox.ts
+++ b/src/recipes/detox.ts
@@ -10,13 +10,19 @@ const addDetoxExpoPlugin = async (toolbox: CycliToolbox) => {
   const currentExpoPlugins =
     toolbox.projectConfig.appJson()?.expo?.plugins || []
 
-  const patch = {
-    expo: {
-      plugins: [...currentExpoPlugins, DETOX_EXPO_PLUGIN],
-    },
-  }
+  const isDetoxExpoPluginAdded =
+    currentExpoPlugins.includes(DETOX_EXPO_PLUGIN) ||
+    toolbox.projectConfig.appJs()?.includes(DETOX_EXPO_PLUGIN)
 
-  await toolbox.projectConfig.patchAppConfig(patch)
+  if (!isDetoxExpoPluginAdded) {
+    const patch = {
+      expo: {
+        plugins: [...currentExpoPlugins, DETOX_EXPO_PLUGIN],
+      },
+    }
+
+    await toolbox.projectConfig.patchAppConfig(patch)
+  }
 }
 
 const execute = async (toolbox: CycliToolbox, context: ProjectContext) => {

--- a/src/recipes/detox.ts
+++ b/src/recipes/detox.ts
@@ -7,35 +7,16 @@ const DETOX_EXPO_PLUGIN = '@config-plugins/detox'
 const FLAG = 'detox'
 
 const addDetoxExpoPlugin = async (toolbox: CycliToolbox) => {
-  const appJsonFile = toolbox.projectConfig.appJsonFile()
+  const currentExpoPlugins =
+    toolbox.projectConfig.appJson()?.expo?.plugins || []
 
-  if (!appJsonFile) {
-    toolbox.interactive.warning(
-      `Cannot write to dynamic config. Make sure to add "${DETOX_EXPO_PLUGIN}" to expo.plugins in app.config.js.`
-    )
-    toolbox.furtherActions.push(
-      `Add "${DETOX_EXPO_PLUGIN}" to expo.plugins in app.config.js.`
-    )
-  } else {
-    const currentExpoPlugins =
-      toolbox.projectConfig.appJson()?.expo?.plugins || []
-
-    if (!currentExpoPlugins.includes(DETOX_EXPO_PLUGIN)) {
-      await toolbox.patching.update(appJsonFile, (config) => {
-        if (!config.expo.plugins) {
-          config.expo.plugins = []
-        }
-
-        if (!config.expo.plugins.includes(DETOX_EXPO_PLUGIN)) {
-          config.expo.plugins.push(DETOX_EXPO_PLUGIN)
-        }
-
-        return config
-      })
-
-      toolbox.interactive.step(`Added ${DETOX_EXPO_PLUGIN} plugin to app.json`)
-    }
+  const patch = {
+    expo: {
+      plugins: [...currentExpoPlugins, DETOX_EXPO_PLUGIN],
+    },
   }
+
+  await toolbox.projectConfig.patchAppConfig(patch)
 }
 
 const execute = async (toolbox: CycliToolbox, context: ProjectContext) => {

--- a/src/recipes/eas.ts
+++ b/src/recipes/eas.ts
@@ -28,7 +28,7 @@ const patchEasJson = async (
     }
   }
 
-  await toolbox.patching.update('eas.json', (config) =>
+  await toolbox.patching.update('eas.json', (config: Record<string, unknown>) =>
     recursiveAssign(config, patch)
   )
 
@@ -44,22 +44,7 @@ const patchAppJson = async (toolbox: CycliToolbox): Promise<void> => {
     },
   }
 
-  const appJsonFile = toolbox.projectConfig.appJsonFile()
-
-  if (!appJsonFile) {
-    toolbox.interactive.warning(
-      `Cannot write to dynamic config. Make sure to set "expo.runtimeVersion.policy" to "fingerprint" in app.config.js.`
-    )
-    toolbox.furtherActions.push(
-      `Set "expo.runtimeVersion.policy" to "fingerprint" in app.config.js.`
-    )
-  } else {
-    await toolbox.patching.update(appJsonFile, (config) =>
-      recursiveAssign(config, patch)
-    )
-  }
-
-  toolbox.interactive.step('Set runtimeVersion policy to "fingerprint".')
+  await toolbox.projectConfig.patchAppConfig(patch)
 }
 
 const execute = async (
@@ -73,17 +58,11 @@ const execute = async (
   await toolbox.dependencies.add('expo-dev-client', context)
   await toolbox.dependencies.add('expo-updates', context)
 
-  if (!toolbox.filesystem.exists('eas.json')) {
-    toolbox.expo.eas.buildConfigure()
-  } else {
-    toolbox.interactive.step(
-      'Detected eas.json file, skipping EAS Build configuration.'
-    )
-  }
+  await toolbox.projectConfig.checkAppNameInConfigOrGenerate()
 
-  toolbox.expo.prebuild(context, { cleanAfter: true })
+  await toolbox.expo.eas.buildConfigure()
 
-  toolbox.expo.eas.credentialsConfigureBuild({
+  await toolbox.expo.eas.credentialsConfigureBuild({
     platform: 'android',
     environment: 'development',
   })
@@ -101,13 +80,13 @@ const execute = async (
   )
 
   if (withIOSCredentials) {
-    toolbox.expo.eas.credentialsConfigureBuild({
+    await toolbox.expo.eas.credentialsConfigureBuild({
       platform: 'ios',
       environment: 'development',
     })
   }
 
-  toolbox.expo.eas.updateConfigure()
+  await toolbox.expo.eas.updateConfigure()
 
   await patchEasJson(toolbox, withIOSCredentials)
   await patchAppJson(toolbox)

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,11 @@ export type Environment = 'development'
 
 export interface AppJson {
   expo?: {
+    slug?: string
     plugins?: string[]
+    ios?: {
+      bundleIdentifier?: string
+    }
     android?: {
       package?: string
     }

--- a/src/utils/recursiveAssign.ts
+++ b/src/utils/recursiveAssign.ts
@@ -2,6 +2,7 @@ import assignWith from 'lodash/assignWith'
 
 type Value =
   | string
+  | string[]
   | number
   | boolean
   | null


### PR DESCRIPTION
Resolves #138 

## Changes

- Stop using `expo prebuild` in EAS Preview recipe. We used it only to patch `app.json`/`app.config.js` with `expo.android.package` and `expo.ios.bundleIdentifier` fields. `expo prebuild` checks if they are missing and if yes, prompts the user to provide them and suggests default values. Now we mimic this behaviour. We use clack text prompt and suggest name equal to `com.${eas_username}.${expo.slug || packageJson.name}`.

<img width="860" alt="Zrzut ekranu 2024-11-26 o 15 52 00" src="https://github.com/user-attachments/assets/55000e67-7d09-4252-94c0-50afbe647da0">

- If we are able to patch the file ourselves, we do it. Otherwise (if the 
file is dynamic, e.g. `app.config.js`), we prompt the user to patch it **before proceeding**, as it might be needed for following steps.

<img width="957" alt="Zrzut ekranu 2024-11-26 o 15 52 20" src="https://github.com/user-attachments/assets/736f19c8-084e-4445-b92a-5fd6420407c4">

- For the previous step, a generic method `ProjectConfigExtension::patchAppConfig()` is introduced. Also, I noticed that our eas dependencies `eas build:configure` and `eas update:configure` can also fail because of not being able to patch dynamic config. With current implementation, `setup-ci` would terminate immediately. Now, I added action prompt waiting for the user to change configuration according to what the downstream said.

<img width="1448" alt="Zrzut ekranu 2024-11-26 o 15 52 49" src="https://github.com/user-attachments/assets/48ea836c-7986-4925-8e8e-f7373a38a0c1">